### PR TITLE
package/tangerine: use `vec-lib` instead of `vec`

### DIFF
--- a/package/tangerine/info.rkt
+++ b/package/tangerine/info.rkt
@@ -14,6 +14,6 @@
 (define deps
   '("base"
     "sandbox-lib"
-    "vec"
+    "vec-lib"
     ["tangerine-x86_64-linux" #:platform #rx"^x86_64-linux(?:-natipkg)?$"]
     ["tangerine-x86_64-win32" #:platform "win32\\x86_64"]))


### PR DESCRIPTION
This avoids dependencies on Scribble and `racket/draw`.

As I mentioned on Discord, you'll need to register `tangarine-x86_64-linux`, `tangerine-x86_64-win32`, and `vec-lib` at https://pkgs.racket-lang.org before the `tangerine` package will work, but it's no more broken with this change than currently.