### PR TITLE
Build with Guix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required(VERSION 3.14)
-project(tangerine)
+cmake_minimum_required(VERSION 3.24)
+project(tangerine
+	DESCRIPTION "Procedural 3D model creation")
 
 if (MSVC)
 	message(FATAL_ERROR 
@@ -7,67 +8,177 @@ if (MSVC)
 		Visual Studio users should open the .sln file directly, instead.")
 endif()
 
+include(GNUInstallDirs)
+
+#######################################################################
+## Build options:
+
 option(EMBED_LUA "Embed Lua support" ON)
 option(EMBED_RACKET "Embed Racket support" OFF)
 
+set(INSTALL_PKG_SUBPATH "tangerine" CACHE PATH
+	"Subdirectory to form PKGDATADIR from DATADIR")
+mark_as_advanced(INSTALL_PKG_SUBPATH)
+
+#######################################################################
+## Required dependencies:
+
+find_package(SDL2 REQUIRED)
+find_package(Threads REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD 17)
 
-file(GLOB_RECURSE TANGERINE_FILES "tangerine/*.cpp")
+
+#######################################################################
+##+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++##
+#######################################################################
+## Set up PKGDATADIR (e.g. "share/tangerine/shaders"):
+
+cmake_path(APPEND CMAKE_INSTALL_DATADIR "${INSTALL_PKG_SUBPATH}"
+	OUTPUT_VARIABLE INSTALL_PKGDATADIR)
+cmake_path(RELATIVE_PATH INSTALL_PKGDATADIR
+	BASE_DIRECTORY CMAKE_INSTALL_BINDIR
+	OUTPUT_VARIABLE PKGDATADIR_FROM_BINDIR)
+cmake_path(APPEND CMAKE_BINARY_DIR "${INSTALL_PKGDATADIR}"
+	OUTPUT_VARIABLE BUILD_PKGDATADIR)
+file(GLOB_RECURSE SHADER_FILES CONFIGURE_DEPENDS
+	"shaders/*.glsl"
+	"shaders/defines.h")
+if(EMBED_LUA)
+	file(GLOB_RECURSE MODELS_LUA_FILES CONFIGURE_DEPENDS "models/*.lua")
+endif()
+if(EMBED_RACKET)
+	file(GLOB_RECURSE MODELS_RKT_FILES CONFIGURE_DEPENDS "models/*.rkt")
+endif()
+cmake_path(APPEND BUILD_PKGDATADIR "shaders" OUTPUT_VARIABLE BUILD_SHADERS_DIR)
+file(MAKE_DIRECTORY "${BUILD_SHADERS_DIR}")
+foreach(X IN LISTS SHADER_FILES)
+	configure_file("${X}" "${BUILD_SHADERS_DIR}" COPYONLY)
+endforeach()
+cmake_path(APPEND BUILD_PKGDATADIR "models" OUTPUT_VARIABLE BUILD_MODELS_DIR)
+file(MAKE_DIRECTORY "${BUILD_MODELS_DIR}")
+foreach(X IN LISTS MODELS_LUA_FILES MODELS_RKT_FILES)
+	configure_file("${X}" "${BUILD_MODELS_DIR}" COPYONLY)
+endforeach()
+install(DIRECTORY "${BUILD_PKGDATADIR}/"
+	DESTINATION $<PATH:APPEND,${CMAKE_INSTALL_FULL_DATADIR},${INSTALL_PKG_SUBPATH}>)
+
+
+#######################################################################
+##+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++##
+#######################################################################
+## Third-Party Libraries:
+
+#######################################################################
+## fmt:
+
+add_library(fmt OBJECT "third_party/fmt/src/format.cc")
+target_include_directories(fmt PUBLIC "third_party/fmt/include")
+
+#######################################################################
+## GLAD:
+
+add_library(glad OBJECT "third_party/glad/glad.c")
+
+#######################################################################
+## GLM:
+
+add_subdirectory("third_party/glm")
+
+#######################################################################
+## ImGui:
+
+file(GLOB TANGERINE_IMGUI_FILES CONFIGURE_DEPENDS
+	"third_party/imgui/*.cpp"
+	"third_party/imgui/backends/imgui_impl_opengl3.cpp"
+	"third_party/imgui/backends/imgui_impl_sdl.cpp")
+add_library(imgui OBJECT "${TANGERINE_IMGUI_FILES}")
+target_link_libraries(imgui PUBLIC SDL2::SDL2)
+# some complexity to make both <imgui/imgui.h> and "imgui.h" work
+# FIXME same problem with glm ... can we just move the source?
+target_include_directories(imgui PUBLIC
+	$<BUILD_INTERFACE:$<PATH:APPEND,${CMAKE_BINARY_DIR},imgui-include-dir>>
+	$<BUILD_INTERFACE:$<PATH:APPEND,${CMAKE_BINARY_DIR},imgui-include-dir/imgui>>
+	$<BUILD_INTERFACE:$<PATH:APPEND,${CMAKE_BINARY_DIR},imgui-include-dir/imgui/backends>>
+	$<INSTALL_INTERFACE:"${CMAKE_INSTALL_FULL_INCLUDEDIR}">)
+file(GLOB TANGERINE_IMGUI_HEADERS CONFIGURE_DEPENDS "third_party/imgui/*.h")
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/imgui-include-dir/imgui/backends")
+foreach(X IN ITEMS "third_party/imgui/backends/imgui_impl_opengl3.h"
+			"third_party/imgui/backends/imgui_impl_sdl.h")
+	configure_file("${X}" "imgui-include-dir/imgui/backends" COPYONLY)
+endforeach()
+foreach(X IN LISTS TANGERINE_IMGUI_HEADERS)
+	configure_file("${X}" "imgui-include-dir/imgui")
+endforeach()
+
+#######################################################################
+## ImFileDialog:
+
+add_library(ImFileDialog OBJECT
+	"third_party/ImFileDialog/ImFileDialog.cpp"
+	"third_party/stb/stb.cpp")
+target_link_libraries(ImFileDialog PUBLIC imgui)
+target_include_directories(ImFileDialog
+	PUBLIC "third_party/ImFileDialog" #/ImFileDialog.h"
+	PRIVATE "third_party/stb") #/stb_image.h")
+
+#######################################################################
+## VoxWriter:
+
+add_library(VoxWriter OBJECT "third_party/voxwriter/VoxWriter.cpp")
+target_sources(VoxWriter
+	PUBLIC FILE_SET HEADERS
+	FILES "third_party/voxwriter/VoxWriter.h")
+
+
+#######################################################################
+##+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++##
+#######################################################################
+## Tangerine, the executable:
+
+file(GLOB_RECURSE TANGERINE_FILES CONFIGURE_DEPENDS "tangerine/*.cpp")
+add_executable(tangerine ${TANGERINE_FILES})
+set_target_properties(tangerine
+	PROPERTIES
+	RUNTIME_OUTPUT_DIRECTORY
+	$<PATH:APPEND,${CMAKE_BINARY_DIR},${CMAKE_INSTALL_BINDIR}>)
+target_compile_definitions(tangerine PRIVATE
+	"TANGERINE_PKGDATADIR_FROM_BINDIR=${PKGDATADIR_FROM_BINDIR}")
+target_link_libraries(tangerine PRIVATE
+	fmt
+	glad
+	glm
+	imgui
+	ImFileDialog
+	VoxWriter
+	tinfo # see https://gitlab.kitware.com/cmake/cmake/-/issues/23236
+	${CMAKE_THREAD_LIBS_INIT}
+	${CMAKE_DL_LIBS})
+install(TARGETS tangerine)
+
+
+#######################################################################
+##+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++##
+#######################################################################
+## Optional Scripting Languages:
+
+#######################################################################
+## Lua:
 
 if(EMBED_LUA)
-	file(GLOB TANGERINE_LUA_FILES "third_party/lua-5.4.4/lua/*.c")
+	file(GLOB TANGERINE_LUA_FILES CONFIGURE_DEPENDS "third_party/lua-5.4.4/lua/*.c")
 	list(FILTER
 		TANGERINE_LUA_FILES
 		EXCLUDE REGEX
 		".*/lua/(onelua|lua|luac)\.c") # these define main
+	add_library(lua OBJECT "${TANGERINE_LUA_FILES}")
+	target_include_directories(lua INTERFACE "third_party/lua-5.4.4")
+	target_link_libraries(tangerine PRIVATE lua)
 endif()
-
-file(GLOB TANGERINE_IMGUI_FILES
-	"third_party/imgui/*.cpp")
-
-set(TANGERINE_THIRD_PARTY_FILES
-	${TANGERINE_IMGUI_FILES}
-	"third_party/imgui/backends/imgui_impl_opengl3.cpp"
-	"third_party/imgui/backends/imgui_impl_sdl.cpp"
-	"third_party/ImFileDialog/ImFileDialog.cpp"
-	"third_party/stb/stb.cpp"
-	"third_party/voxwriter/VoxWriter.cpp"
-	"third_party/fmt/src/format.cc"
-	"third_party/glad/glad.c"
-	${TANGERINE_LUA_FILES})
-
-set(TANGERINE_INCLUDE_DIRS
-	"third_party"
-	"third_party/fmt/include"
-	"third_party/imgui"
-	"third_party/imgui/backends"
-	"third_party/ImFileDialog"
-	"third_party/stb")
-
-if(EMBED_LUA)
-	list(APPEND TANGERINE_INCLUDE_DIRS "third_party/lua-5.4.4")
-endif()
-if(EMBED_RACKET)
-	list(APPEND TANGERINE_INCLUDE_DIRS "third_party/racket/include")
-endif()
-
-add_executable(tangerine
-	${TANGERINE_FILES}
-	${TANGERINE_THIRD_PARTY_FILES})
-
-find_package(SDL2 REQUIRED)
-
-find_package(PkgConfig REQUIRED)
-
-include_directories(
-	${TANGERINE_INCLUDE_DIRS})
-
 target_compile_definitions(tangerine PRIVATE
-	"EMBED_LUA=$<BOOL:${EMBED_LUA}>"
-	"EMBED_RACKET=$<BOOL:${EMBED_RACKET}>")
+	"EMBED_LUA=$<BOOL:${EMBED_LUA}>")
 
-target_link_libraries(tangerine
-	SDL2::SDL2
-	"$<$<BOOL:${EMBED_RACKET}>:racketcs>"
-	tinfo)
+#######################################################################
+## Racket:
+
+# FIXME!

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Tangerine currently supports Windows and Linux:
 
  * The Linux version must be built from source.
    Build instructions are at the end of this readme.
+   Optionally, you can use Guix to automate the build process.
 
 # Getting Started
 
@@ -34,14 +35,43 @@ There is also [API reference documentation](docs/lua_api.md) available.
 
 ## Linux
 
- 1. Install cmake, clang, and SDL2 by whatever means are appropriate for your distro.
+You can build the project directly, or you can use [Guix](https://guix.gnu.org) to manage the build environment.
+
+### Building Manually
+
+ 1. Install CMake, a C++17 toolchain (Clang and GCC both seem to work), and SDL2 by whatever means are appropriate for your distro.
+    (If you encounter errors about linking to `tinfo`, the problem may be related to Curses.)
     The other dependencies are provided by this repository.
     As several of the included dependencies contain modifications for this project, it is not advisable to replace them with packaged dependencies.
     I apologize for the convenience.
 
  2. Clone this project somewhere.
 
- 3. Run `linux/build_majuscule.sh`.
+ 3. Run `./linux/build_majuscule.sh`.
 
- 4. If all goes well, the binary will show up in `linux/build/Release/tangerine`.
-    Rename it to something like `a.out` and copy it into the root project folder (it must be in the same directory as the `shaders` folder to work).
+ 4. If all goes well, the binary will show up in `./linux/build/Release/bin/tangerine`: you can run it directly from the build directory.
+    (If you want to move it somewhere else, beware that it must find some runtime data from a path relative to the executable: `cmake --install` handles keeping them together.)
+
+Of course, `./linux/build_majuscule.sh` just runs `cmake` with some sensible options.
+If you prefer, you can always run `cmake` directly.
+
+### Building with Guix
+
+If you install Guix (which may be as easy as `sudo apt install guix`), you don't have to worry about any of the other dependencies.
+
+To run Tangerine, automatically building it if needed, try:
+
+```sh
+guix time-machine -C channels.scm -- \
+  shell --rebuild-cache -f guix.scm -- \
+    tangerine
+```
+
+You can create an isolated container and enter a shell for interactive building by running:
+
+```sh
+guix time-machine -C channels.scm -- \
+  shell --rebuild-cache -D -f guix.scm --container --emulate-fhs
+```
+
+Adding `-- ./linux/build_majuscule.sh` to the end of that command will perform a build in the same way as the manual process described above.

--- a/channels.scm
+++ b/channels.scm
@@ -1,0 +1,11 @@
+(list (channel
+        (name 'guix)
+        (url "https://git.savannah.gnu.org/git/guix.git")
+        (branch "master")
+        (commit
+          "67d2f688fb89553df53e73a4c584b1b9eb7d5c24")
+        (introduction
+          (make-channel-introduction
+            "9edb3f66fd807b096b48283debdcddccfea34bad"
+            (openpgp-fingerprint
+              "BBB0 2DDF 2CEA F6A8 0D1D  E643 A2A0 6DF2 A33A 54FA")))))

--- a/guix.scm
+++ b/guix.scm
@@ -1,0 +1,64 @@
+;; A Guix package to build Tangerine from a local checkout
+
+(use-modules
+ (gnu packages cmake)
+ (gnu packages ncurses)
+ (gnu packages sdl)
+ (guix build-system cmake)
+ (guix gexp)
+ (guix git-download)
+ ((guix licenses) #:prefix license:)
+ (guix packages)
+ (guix utils)
+ (ice-9 regex))
+
+(define-public %tangerine-origin
+  (local-file
+   "." "tangerine-src"
+   #:recursive? #t
+   #:select?
+   (let* ((src-dir (current-source-directory))
+          (checked-in?
+           (or (and src-dir
+                    (git-predicate (canonicalize-path src-dir)))
+               (lambda (path stat)
+                 #t)))
+          (so-dll-rx
+           (make-regexp "\\.(so|dll)$"))
+          (so-or-dll?
+           (lambda (path stat)
+             (regexp-exec so-dll-rx path)))
+          (source-file?
+           (lambda (path stat)
+             (and (checked-in? path stat)
+                  (not (so-or-dll? path stat))))))
+     source-file?)))
+
+(define-public tangerine
+  (package
+    (name "tangerine")
+    (version "0.0")
+    (source %tangerine-origin)
+    (outputs '("out" "debug"))
+    (build-system cmake-build-system)
+    (inputs
+     (list ncurses/tinfo ; for -ltinfo
+           sdl2
+           ;; are the rest needed?
+           sdl2-image
+           sdl2-mixer
+           sdl2-ttf))
+    (arguments
+     (list
+      #:cmake cmake ; newer than cmake-minimal
+      #:tests? #f))
+    (home-page "https://github.com/Aeva/tangerine")
+    (synopsis "Procedural 3D model creation")
+    (description
+     "Tangerine is a system for creating 3D models procedurally from a set
+of Signed Distance Function (SDF) primitive shapes and combining
+operators.  Models are written in Lua, and may be either rendered
+directly or exported to a variety of common 3D model file formats.")
+    (license license:asl2.0)))
+
+tangerine

--- a/linux/build_majuscule.sh
+++ b/linux/build_majuscule.sh
@@ -2,11 +2,7 @@
 cd `dirname $0`
 cd ..
 
-cmake -B linux/build/Debug -DCMAKE_BUILD_TYPE=Debug \
-  -DCMAKE_CXX_COMPILER=clang++ \
-  -DCMAKE_C_COMPILER=clang
-cmake -B linux/build/Release -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CXX_COMPILER=clang++ \
-  -DCMAKE_C_COMPILER=clang
+cmake -B linux/build/Debug -DCMAKE_BUILD_TYPE=Debug
+cmake -B linux/build/Release -DCMAKE_BUILD_TYPE=Release
 
-cmake --build linux/build/Release
+exec cmake --build linux/build/Release

--- a/tangerine/gl_boilerplate.cpp
+++ b/tangerine/gl_boilerplate.cpp
@@ -20,9 +20,9 @@
 #include <mutex>
 #include "gl_boilerplate.h"
 #include "profiling.h"
+#include "installation.h"
 
-
-extern std::filesystem::path ShadersDir;
+extern TangerineInstallation Installed;
 
 
 inline GLsizei min(GLsizei LHS, GLsizei RHS)
@@ -138,7 +138,7 @@ StatusCode FillSources(std::vector<std::string>& BreadCrumbs, std::vector<std::s
 	}
 	BreadCrumbs.push_back(Path);
 
-	std::filesystem::path FullPath = ShadersDir / Path;
+	std::filesystem::path FullPath = Installed.ShadersDir / Path;
 
 	std::ifstream File(FullPath);
 	if (!File.is_open())

--- a/tangerine/installation.cpp
+++ b/tangerine/installation.cpp
@@ -1,0 +1,54 @@
+
+// Copyright 2023 Philip McGrath
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "installation.h"
+#if !(defined(TANGERINE_WINDOWS) || EMBED_RACKET)
+# include <unistd.h>
+#endif
+
+std::filesystem::path tangerine_get_self_exe_path(char* argv0)
+{
+#if defined(TANGERINE_WINDOWS)
+        // Is this really right? Should it use GetModuleFileNameW?
+        return std::filesystem::absolute(argv0);
+#elif EMBED_RACKET
+        return std::filesystem::path(racket_get_self_exe_path(argv0));
+#else
+        // limited fallback support for linux
+        char *s;
+        ssize_t len, blen = 256;
+
+        s = (char*)malloc(blen);
+
+        while (1) {
+                len = readlink("/proc/self/exe", s, blen-1);
+                if (len == (blen-1)) {
+                        free(s);
+                        blen *= 2;
+                        s = (char*)malloc(blen);
+                } else if (len < 0) {
+                        /* possibly in a chroot environment where "/proc" is not
+                           available, so fall back to generic approach: */
+                        free(s);
+                        return std::filesystem::absolute(argv0);
+                } else
+                        break;
+        }
+        s[len] = 0;
+        std::filesystem::path ret = std::filesystem::path(s);
+        free(s);
+        return ret;
+#endif
+};

--- a/tangerine/installation.h
+++ b/tangerine/installation.h
@@ -1,0 +1,50 @@
+
+// Copyright 2023 Philip McGrath
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <filesystem>
+#include "embedding.h"
+
+#if defined(_MSC_VER) || defined(__MINGW32__)
+# define TANGERINE_WINDOWS
+#else
+# define TANGERINE_UNIX
+#endif
+
+std::filesystem::path tangerine_get_self_exe_path(char* argv0);
+
+struct TangerineInstallation
+{
+        char* argv0;
+        std::filesystem::path SelfExePath = tangerine_get_self_exe_path(argv0);
+        std::filesystem::path ExecutableDir = SelfExePath.parent_path();
+        std::filesystem::path PkgDataDir {
+#ifdef TANGERINE_PKGDATADIR_FROM_BINDIR
+# define AS_a_STR_HELPER(x) #x
+# define AS_a_STR(x) AS_a_STR_HELPER(x)
+# define TPFB TANGERINE_PKGDATADIR_FROM_BINDIR
+		ExecutableDir / std::filesystem::path(AS_a_STR(TPFB))
+# undef TPFB
+# undef AS_a_STR
+# undef AS_a_STR_HELPER
+#else
+		ExecutableDir
+#endif
+	};
+        std::filesystem::path ShadersDir =
+		PkgDataDir / std::filesystem::path("shaders");
+        std::filesystem::path ModelsDir =
+		PkgDataDir / std::filesystem::path("models");
+};

--- a/tangerine/tangerine.cpp
+++ b/tangerine/tangerine.cpp
@@ -59,7 +59,7 @@
 #include "gl_async.h"
 #include "gl_debug.h"
 #include "../shaders/defines.h"
-
+#include "installation.h"
 
 // TODO: These were originally defined as a cross-platform compatibility hack for code
 // in this file that was using min/max macros from a Windows header.  The header is no
@@ -85,9 +85,7 @@ ScriptEnvironment* MainEnvironment = nullptr;
 SDFNode* TreeEvaluator = nullptr;
 
 
-std::filesystem::path ExecutableDir;
-std::filesystem::path ShadersDir;
-std::filesystem::path ModelsDir;
+TangerineInstallation Installed;
 std::filesystem::path LastOpenDir;
 
 
@@ -1749,7 +1747,9 @@ void RenderUI(SDL_Window* Window, bool& Live)
 
 void LoadBookmarks()
 {
-	std::filesystem::path BookmarksPath = ExecutableDir / "bookmarks.txt";
+	std::filesystem::path BookmarksPath =
+                // FIXME might be read-only
+                Installed.ExecutableDir / "bookmarks.txt";
 	if (std::filesystem::is_regular_file(BookmarksPath))
 	{
 		std::ifstream BookmarksFile;
@@ -1772,7 +1772,9 @@ void LoadBookmarks()
 
 void SaveBookmarks()
 {
-	std::filesystem::path BookmarksPath = ExecutableDir / "bookmarks.txt";
+	std::filesystem::path BookmarksPath =
+		// FIXME might be read-only
+		Installed.ExecutableDir / "bookmarks.txt";
 	const std::vector<std::string>& Bookmarks = ifd::FileDialog::Instance().GetFavorites();
 	if (Bookmarks.size() > 0)
 	{
@@ -1792,10 +1794,8 @@ SDL_GLContext Context = nullptr;
 
 StatusCode Boot(int argc, char* argv[])
 {
-	ExecutableDir = std::filesystem::absolute(argv[0]).parent_path();
-	ShadersDir = ExecutableDir / std::filesystem::path("Shaders");
-	ModelsDir = ExecutableDir / std::filesystem::path("Models");
-	LastOpenDir = ModelsDir;
+	Installed = { argv[0] };
+	LastOpenDir = Installed.ModelsDir;
 	LoadBookmarks();
 
 	std::vector<std::string> Args;


### PR DESCRIPTION
**Current status:** See https://github.com/Aeva/tangerine/pull/8#issuecomment-1427873891 to try it out!

----

## Original Post

> Currently, building with `guix time-machine -C channels.scm -- build -f guix.scm --keep-failed` hits the following error: I've attaching the full log as [9f5hc6rgfdmwv8wkw6rwi8n79nbkr5np-tangerine-0.0.drv.log](https://github.com/Aeva/tangerine/files/10718650/9f5hc6rgfdmwv8wkw6rwi8n79nbkr5np-tangerine-0.0.drv.log).
> 
> ```
> /tmp/guix-build-tangerine-0.0.drv-0/source/tangerine/lua_sdf.cpp:533:11: error: no matching function for call to 'min'
>                         Dist = glm::min(abs(Dist), MaxDist);
>                                ^~~~~~~~
> /tmp/guix-build-tangerine-0.0.drv-0/source/third_party/glm/detail/func_common.inl:17:43: note: candidate template ignored: deduced conflicting types for parameter 'genType' ('int' vs. 'float')
>         GLM_FUNC_QUALIFIER GLM_CONSTEXPR genType min(genType x, genType y)
> ```
> 
> There are a bunch of warnings like this that might or might not be related:
> ```
> /tmp/guix-build-tangerine-0.0.drv-0/source/tangerine/lua_sdf.cpp:533:20: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
>                         Dist = glm::min(abs(Dist), MaxDist);
>                                         ^
> /tmp/guix-build-tangerine-0.0.drv-0/source/tangerine/lua_sdf.cpp:533:20: note: use function 'std::abs' instead
>                         Dist = glm::min(abs(Dist), MaxDist);
>                                         ^~~
>                                         std::abs
> ```