### PR TITLE
Add flake file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ bookmarks.txt
 .\#*
 .DS_Store
 *.kate-swp
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixgl": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1710868679,
+        "narHash": "sha256-V1o2bCZdeYKP/0zgVp4EN0KUjMItAMk6J7SvCXUI5IU=",
+        "owner": "nix-community",
+        "repo": "nixGL",
+        "rev": "d709a8abcde5b01db76ca794280745a43c8662be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixGL",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1712168706,
+        "narHash": "sha256-XP24tOobf6GGElMd0ux90FEBalUtw6NkBSVh/RlA6ik=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1487bdea619e4a7a53a4590c475deabb5a9d1bfb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixgl": "nixgl",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,43 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    nixgl.url = "github:nix-community/nixGL";
+    nixgl.inputs.nixpkgs.follows = "nixpkgs";
+  };
+  outputs = {self, nixpkgs, nixgl}:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ nixgl.overlay ];
+        config = { allowUnfree = true; };
+      };
+    in
+    {
+      packages.${system} = {
+        tangerine = pkgs.stdenv.mkDerivation {
+          name = "tangerine";
+          patches = [
+            (pkgs.fetchpatch {
+              url = "https://github.com/Aeva/tangerine/pull/12/commits/2d7d1ae1e21e8fe52df2c4a33e947b2ff6b07812.patch";
+              hash = "sha256-zLAx5FOvtUsUZM/nUCFW8Z1Xe3+oV95Nv1s3GaNcV/c=";
+            })
+          ];
+          nativeBuildInputs = [ pkgs.cmake ];
+          buildInputs = with pkgs; [ SDL2 ncurses ];
+          src = ./.;
+          inherit system;
+        };
+        default = pkgs.writeScriptBin "tangerine"
+          ''
+          ${pkgs.nixgl.nixGLIntel}/bin/nixGLIntel ${self.packages.${system}.tangerine}/bin/tangerine
+          '';
+      };
+      devShells.${system}.default = pkgs.mkShell {
+        buildInputs = with pkgs; [ cmake SDL2 ncurses pkgs.nixgl.nixGLIntel ];
+        shellHook = ''
+          export LD_LIBRARY_PATH=$(nixGLIntel printenv LD_LIBRARY_PATH):$LD_LIBRARY_PATH
+        '';
+      };
+    };
+}


### PR DESCRIPTION
Usage:
```
nix run  # run tangerine (default package)
nix develop  # enter development shell (cmake + dependencies available)
nix build  # get tangerine built and available in result/bin/
```

To enable flake commands in your environment, see https://nixos.wiki/wiki/Flakes#Enable_flakes_permanently_in_NixOS

Depending on your environment, you may want nixGLNvidia instead of nixGLIntel. I didn't go as far as parametrising / exposing that.